### PR TITLE
Add MobileNetV2 transfer learning setup

### DIFF
--- a/waste_classification.py
+++ b/waste_classification.py
@@ -1,6 +1,7 @@
 import torch
+from torch import nn
 from torch.utils.data import DataLoader, random_split
-from torchvision import datasets, transforms
+from torchvision import datasets, models, transforms
 
 
 def main() -> None:
@@ -42,6 +43,21 @@ def main() -> None:
     print("Classes:", full_dataset.classes)
     print("Train batches:", len(train_loader))
     print("Val batches:", len(val_loader))
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    model = models.mobilenet_v2(weights=models.MobileNet_V2_Weights.DEFAULT)
+    for parameter in model.parameters():
+        parameter.requires_grad = False
+
+    num_classes = len(full_dataset.classes)
+    model.classifier = nn.Sequential(
+        nn.Dropout(p=0.5),
+        nn.Linear(model.last_channel, num_classes),
+    )
+    model = model.to(device)
+
+    print(model)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Provide a ready-to-use MobileNetV2 backbone for waste classification using transfer learning.
- Freeze pre-trained feature extractor weights to train only the final classifier layer.
- Replace the default classifier with a smaller head matching the dataset's number of classes.
- Ensure the model runs on the available device and print the architecture for verification.

### Description
- Import `models` and `nn` and instantiate `models.mobilenet_v2(weights=models.MobileNet_V2_Weights.DEFAULT)` as the backbone.
- Freeze backbone parameters by setting `parameter.requires_grad = False` for every `parameter` in `model.parameters()`.
- Replace `model.classifier` with `nn.Sequential(nn.Dropout(p=0.5), nn.Linear(model.last_channel, num_classes))` where `num_classes = len(full_dataset.classes)`.
- Move the model to the device with `model = model.to(device)` and print the model with `print(model)`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963625fa9c48325aa35e76e30e12627)