### PR TITLE
Add training loop and optimizer for MobileNetV2 transfer learning

### DIFF
--- a/waste_classification.py
+++ b/waste_classification.py
@@ -1,6 +1,7 @@
 import torch
+from torch import nn, optim
 from torch.utils.data import DataLoader, random_split
-from torchvision import datasets, transforms
+from torchvision import datasets, models, transforms
 
 
 def main() -> None:
@@ -43,7 +44,103 @@ def main() -> None:
     print("Train batches:", len(train_loader))
     print("Val batches:", len(val_loader))
 
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    model = models.mobilenet_v2(weights=models.MobileNet_V2_Weights.DEFAULT)
+    for parameter in model.parameters():
+        parameter.requires_grad = False
+
+    num_classes = len(full_dataset.classes)
+    model.classifier = nn.Sequential(
+        nn.Dropout(p=0.5),
+        nn.Linear(model.last_channel, num_classes),
+    )
+    model = model.to(device)
+
+    print(model)
+
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.Adam(model.classifier.parameters(), lr=1e-4)
+
+    _ = train_model(
+        model,
+        train_loader,
+        val_loader,
+        criterion,
+        optimizer,
+        device,
+        num_epochs=20,
+    )
+
 
 if __name__ == "__main__":
     torch.manual_seed(42)
     main()
+
+
+def train_model(
+    model: nn.Module,
+    train_loader: DataLoader,
+    val_loader: DataLoader,
+    criterion: nn.Module,
+    optimizer: optim.Optimizer,
+    device: torch.device,
+    num_epochs: int = 20,
+) -> dict[str, list[float]]:
+    history = {
+        "train_loss": [],
+        "train_acc": [],
+        "val_loss": [],
+        "val_acc": [],
+    }
+
+    for _ in range(num_epochs):
+        model.train()
+        running_loss = 0.0
+        running_corrects = 0
+        total_samples = 0
+
+        for inputs, labels in train_loader:
+            inputs = inputs.to(device)
+            labels = labels.to(device)
+
+            optimizer.zero_grad()
+            outputs = model(inputs)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+
+            running_loss += loss.item() * inputs.size(0)
+            _, preds = torch.max(outputs, 1)
+            running_corrects += torch.sum(preds == labels).item()
+            total_samples += labels.size(0)
+
+        epoch_loss = running_loss / total_samples if total_samples else 0.0
+        epoch_acc = running_corrects / total_samples if total_samples else 0.0
+        history["train_loss"].append(epoch_loss)
+        history["train_acc"].append(epoch_acc)
+
+        model.eval()
+        val_loss = 0.0
+        val_corrects = 0
+        val_samples = 0
+
+        with torch.no_grad():
+            for inputs, labels in val_loader:
+                inputs = inputs.to(device)
+                labels = labels.to(device)
+
+                outputs = model(inputs)
+                loss = criterion(outputs, labels)
+
+                val_loss += loss.item() * inputs.size(0)
+                _, preds = torch.max(outputs, 1)
+                val_corrects += torch.sum(preds == labels).item()
+                val_samples += labels.size(0)
+
+        epoch_val_loss = val_loss / val_samples if val_samples else 0.0
+        epoch_val_acc = val_corrects / val_samples if val_samples else 0.0
+        history["val_loss"].append(epoch_val_loss)
+        history["val_acc"].append(epoch_val_acc)
+
+    return history


### PR DESCRIPTION
### Motivation
- Provide an end-to-end MobileNetV2 transfer learning workflow including training and validation.
- Fine-tune only the classifier head while freezing the pre-trained backbone to adapt the model to the dataset classes.
- Ensure training runs on the available device by moving the model and batch tensors to `device` during the loop.
- Track loss and accuracy across epochs so results can be plotted or monitored.

### Description
- Add `optim` import and configure `criterion = nn.CrossEntropyLoss()` and `optimizer = optim.Adam(model.classifier.parameters(), lr=1e-4)`.
- Instantiate `models.mobilenet_v2(...)`, freeze backbone parameters, replace `model.classifier` with a head sized to `len(full_dataset.classes)`, and move the model to `device`.
- Implement `train_model(...)` which performs the training and validation phases, moves `inputs` and `labels` to `device`, updates parameters, computes loss/accuracy, and appends per-epoch metrics to a `history` dict.
- Invoke `train_model` from `main` with `num_epochs=20` and capture the returned history for plotting/inspection.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963625fa9c48325aa35e76e30e12627)