### PR TITLE
Add training, evaluation and visualization pipeline to waste_classification.py

### DIFF
--- a/waste_classification.py
+++ b/waste_classification.py
@@ -1,7 +1,86 @@
+import matplotlib.pyplot as plt
+import seaborn as sns
 import torch
+from sklearn.metrics import classification_report, confusion_matrix
 from torch import nn
 from torch.utils.data import DataLoader, random_split
 from torchvision import datasets, models, transforms
+
+
+def train_model(
+    model: nn.Module,
+    train_loader: DataLoader,
+    val_loader: DataLoader,
+    criterion: nn.Module,
+    optimizer: torch.optim.Optimizer,
+    device: torch.device,
+    epochs: int = 20,
+) -> dict:
+    history = {
+        "train_loss": [],
+        "train_acc": [],
+        "val_loss": [],
+        "val_acc": [],
+    }
+
+    for epoch in range(epochs):
+        model.train()
+        running_loss = 0.0
+        running_correct = 0
+        total = 0
+
+        for inputs, labels in train_loader:
+            inputs = inputs.to(device)
+            labels = labels.to(device)
+
+            optimizer.zero_grad()
+            outputs = model(inputs)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+
+            running_loss += loss.item() * inputs.size(0)
+            preds = torch.argmax(outputs, dim=1)
+            running_correct += (preds == labels).sum().item()
+            total += labels.size(0)
+
+        epoch_train_loss = running_loss / total if total else 0.0
+        epoch_train_acc = running_correct / total if total else 0.0
+        history["train_loss"].append(epoch_train_loss)
+        history["train_acc"].append(epoch_train_acc)
+
+        model.eval()
+        val_loss = 0.0
+        val_correct = 0
+        val_total = 0
+
+        with torch.no_grad():
+            for inputs, labels in val_loader:
+                inputs = inputs.to(device)
+                labels = labels.to(device)
+
+                outputs = model(inputs)
+                loss = criterion(outputs, labels)
+
+                val_loss += loss.item() * inputs.size(0)
+                preds = torch.argmax(outputs, dim=1)
+                val_correct += (preds == labels).sum().item()
+                val_total += labels.size(0)
+
+        epoch_val_loss = val_loss / val_total if val_total else 0.0
+        epoch_val_acc = val_correct / val_total if val_total else 0.0
+        history["val_loss"].append(epoch_val_loss)
+        history["val_acc"].append(epoch_val_acc)
+
+        print(
+            f"Epoch [{epoch + 1}/{epochs}] "
+            f"Train Loss: {epoch_train_loss:.4f} "
+            f"Train Acc: {epoch_train_acc:.4f} "
+            f"Val Loss: {epoch_val_loss:.4f} "
+            f"Val Acc: {epoch_val_acc:.4f}"
+        )
+
+    return history
 
 
 def main() -> None:
@@ -9,7 +88,7 @@ def main() -> None:
         [
             transforms.Resize((224, 224)),
             transforms.RandomHorizontalFlip(),
-            transforms.RandomRotation(10),
+            transforms.RandomRotation(15),
             transforms.ToTensor(),
             transforms.Normalize(
                 mean=[0.485, 0.456, 0.406],
@@ -47,9 +126,11 @@ def main() -> None:
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     model = models.mobilenet_v2(weights=models.MobileNet_V2_Weights.DEFAULT)
+    # Transfer Learning: freeze backbone feature extractor layers.
     for parameter in model.parameters():
         parameter.requires_grad = False
 
+    # Transfer Learning: replace the classification head for the new dataset.
     num_classes = len(full_dataset.classes)
     model.classifier = nn.Sequential(
         nn.Dropout(p=0.5),
@@ -57,7 +138,67 @@ def main() -> None:
     )
     model = model.to(device)
 
-    print(model)
+    criterion = nn.CrossEntropyLoss()
+    optimizer = torch.optim.Adam(model.classifier.parameters(), lr=1e-4)
+
+    history = train_model(
+        model=model,
+        train_loader=train_loader,
+        val_loader=val_loader,
+        criterion=criterion,
+        optimizer=optimizer,
+        device=device,
+        epochs=20,
+    )
+
+    epochs_range = range(1, len(history["train_loss"]) + 1)
+    fig, axes = plt.subplots(1, 2, figsize=(14, 5))
+    axes[0].plot(epochs_range, history["train_loss"], label="Train Loss")
+    axes[0].plot(epochs_range, history["val_loss"], label="Val Loss")
+    axes[0].set_title("Training vs Validation Loss")
+    axes[0].set_xlabel("Epoch")
+    axes[0].set_ylabel("Loss")
+    axes[0].legend()
+
+    axes[1].plot(epochs_range, history["train_acc"], label="Train Acc")
+    axes[1].plot(epochs_range, history["val_acc"], label="Val Acc")
+    axes[1].set_title("Training vs Validation Accuracy")
+    axes[1].set_xlabel("Epoch")
+    axes[1].set_ylabel("Accuracy")
+    axes[1].legend()
+    plt.tight_layout()
+    plt.show()
+
+    all_preds = []
+    all_labels = []
+    model.eval()
+    with torch.no_grad():
+        for inputs, labels in val_loader:
+            inputs = inputs.to(device)
+            labels = labels.to(device)
+            outputs = model(inputs)
+            preds = torch.argmax(outputs, dim=1)
+            all_preds.extend(preds.cpu().numpy())
+            all_labels.extend(labels.cpu().numpy())
+
+    class_names = full_dataset.classes
+    cm = confusion_matrix(all_labels, all_preds)
+    plt.figure(figsize=(8, 6))
+    sns.heatmap(
+        cm,
+        annot=True,
+        fmt="d",
+        cmap="Blues",
+        xticklabels=class_names,
+        yticklabels=class_names,
+    )
+    plt.title("Confusion Matrix")
+    plt.xlabel("Predicted")
+    plt.ylabel("True")
+    plt.tight_layout()
+    plt.show()
+
+    print(classification_report(all_labels, all_preds, target_names=class_names))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Provide a complete end-to-end training and evaluation script for the Intelligent Waste Classification System using transfer learning with `MobileNetV2`.
- Add robust device handling so the script runs on GPU (`cuda`) when available and on CPU otherwise.
- Enable interpretability and reporting by adding training/validation curves and a confusion matrix for publication-quality figures.
- Keep the code Colab-ready with standard transforms and dataset loading via `ImageFolder`.

### Description
- Added a reusable training loop function `train_model` that tracks epoch-level training/validation loss and accuracy and returns a `history` dictionary. 
- Implemented transfer learning by loading `MobileNetV2` pretrained weights, freezing the backbone parameters, and replacing the classifier head with `nn.Sequential(nn.Dropout(p=0.5), nn.Linear(model.last_channel, num_classes))` while only optimizing the classifier parameters with `torch.optim.Adam` at `lr=1e-4`.
- Expanded data handling to use `ImageFolder` with an 80/20 `random_split`, updated training transforms (including `RandomRotation(15)`), and created `DataLoader`s with `batch_size=32` and proper device transfers for inputs/labels.
- Added evaluation and visualization: plotting training vs validation loss/accuracy with `matplotlib`, generating a confusion matrix with `seaborn.heatmap`, and printing a `classification_report` from `sklearn.metrics`.

### Testing
- No automated tests were run for this change (script-only update).
- Recommend running the script on a dataset at `./dataset` or in Google Colab with GPU to validate end-to-end behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696363e265448325842236ed5c3992b4)